### PR TITLE
fix: correct PostDetail import path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import './App.css';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Posts from './components/Posts';
-import PostDetail from './components/Postdetail';
+import PostDetail from './components/PostDetail';
 
 function App(): JSX.Element {
   return (


### PR DESCRIPTION
## Summary
- fix import path casing for PostDetail component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb5122f3588321984667a1903bf6d6